### PR TITLE
[Update] -> Handle auth callback tokens & UI/layout tweaks

### DIFF
--- a/buck/src/app/auth/callback/route.ts
+++ b/buck/src/app/auth/callback/route.ts
@@ -15,6 +15,11 @@ function getSafeNextPath(value: string | null) {
   return value;
 }
 
+function escapeForInlineJsString(value: string) {
+  // Produces a JavaScript-string-safe representation (without surrounding quotes).
+  return JSON.stringify(value).slice(1, -1);
+}
+
 function createAppRedirect(request: NextRequest, path: string) {
   return new URL(getSafeNextPath(path), request.nextUrl.origin);
 }
@@ -67,6 +72,11 @@ export async function GET(request: NextRequest) {
     // Fallback for implicit flow (hash fragment)
     // If the URL has a hash fragment, the server can't see it.
     // We return a small HTML page that checks the hash and either redirects to the nextPath or to sign-in.
+    const escapedNextPath = escapeForInlineJsString(nextPath);
+    const escapedMissingCodeRedirect = escapeForInlineJsString(
+      createSignInRedirect(request, "auth-callback-missing-code").toString()
+    );
+
     return new NextResponse(
       `
       <!DOCTYPE html>
@@ -74,9 +84,9 @@ export async function GET(request: NextRequest) {
         <head>
           <script>
             if (window.location.hash && window.location.hash.includes("access_token")) {
-              window.location.replace("${nextPath}" + window.location.hash);
+              window.location.replace("${escapedNextPath}" + window.location.hash);
             } else {
-              window.location.replace("${createSignInRedirect(request, "auth-callback-missing-code").toString()}");
+              window.location.replace("${escapedMissingCodeRedirect}");
             }
           </script>
         </head>

--- a/buck/src/app/auth/callback/route.ts
+++ b/buck/src/app/auth/callback/route.ts
@@ -34,6 +34,8 @@ export async function GET(request: NextRequest) {
   }
 
   const code = request.nextUrl.searchParams.get("code");
+  const token_hash = request.nextUrl.searchParams.get("token_hash");
+  const type = request.nextUrl.searchParams.get("type") as "recovery" | "invite" | "signup" | "magiclink" | "email" | null;
   const nextPath = getSafeNextPath(request.nextUrl.searchParams.get("next"));
   const redirectResponse = NextResponse.redirect(
     createAppRedirect(request, nextPath)
@@ -53,7 +55,7 @@ export async function GET(request: NextRequest) {
     },
   });
 
-  if (!code) {
+  if (!code && !token_hash) {
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -62,19 +64,48 @@ export async function GET(request: NextRequest) {
       return redirectResponse;
     }
 
-    return NextResponse.redirect(
-      createSignInRedirect(request, "auth-callback-missing-code")
+    // Fallback for implicit flow (hash fragment)
+    // If the URL has a hash fragment, the server can't see it.
+    // We return a small HTML page that checks the hash and either redirects to the nextPath or to sign-in.
+    return new NextResponse(
+      `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <script>
+            if (window.location.hash && window.location.hash.includes("access_token")) {
+              window.location.replace("${nextPath}" + window.location.hash);
+            } else {
+              window.location.replace("${createSignInRedirect(request, "auth-callback-missing-code").toString()}");
+            }
+          </script>
+        </head>
+        <body>Redirecting...</body>
+      </html>
+      `,
+      { headers: { "Content-Type": "text/html" } }
     );
   }
 
-  const { error } = await supabase.auth.exchangeCodeForSession(code);
+  if (token_hash && type) {
+    const { error } = await supabase.auth.verifyOtp({ token_hash, type });
+    if (error) {
+      console.error("Auth callback OTP verification failed:", error.message);
+      return NextResponse.redirect(createSignInRedirect(request, "auth-callback-failed"));
+    }
+    return redirectResponse;
+  }
 
-  if (error) {
-    console.error("Auth callback exchange failed:", error.message);
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
 
-    return NextResponse.redirect(
-      createSignInRedirect(request, "auth-callback-failed")
-    );
+    if (error) {
+      console.error("Auth callback exchange failed:", error.message);
+
+      return NextResponse.redirect(
+        createSignInRedirect(request, "auth-callback-failed")
+      );
+    }
   }
 
   return redirectResponse;

--- a/buck/src/app/dashboard/admin/page.tsx
+++ b/buck/src/app/dashboard/admin/page.tsx
@@ -154,7 +154,7 @@ export default function AdminPage() {
   });
 
   return (
-    <main className="admin-page">
+    <div className="admin-page">
       {error && (
         <div style={{ color: "#a81919", background: "rgba(255, 56, 56, 0.14)", padding: "1rem", borderRadius: "8px", border: "1px solid rgba(255, 56, 56, 0.34)", marginBottom: "1rem", flexShrink: 0 }}>
           {error}
@@ -340,6 +340,6 @@ export default function AdminPage() {
           </article>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/buck/src/app/dashboard/expenses/page.tsx
+++ b/buck/src/app/dashboard/expenses/page.tsx
@@ -236,7 +236,7 @@ export default function ExpensesPage() {
   }
 
   return (
-    <main className="expenses-page">
+    <div className="expenses-page">
       {error ? <div className="expenses-message">{error}</div> : null}
 
       <section className="expenses-stats">
@@ -351,6 +351,6 @@ export default function ExpensesPage() {
           )}
         </section>
       </section>
-    </main>
+    </div>
   );
 }

--- a/buck/src/app/dashboard/financial-advisor/page.tsx
+++ b/buck/src/app/dashboard/financial-advisor/page.tsx
@@ -217,7 +217,7 @@ export default function FinancialAdvisorPage() {
   }
 
   return (
-    <main className="advisor-page">
+    <div className="advisor-page">
       {error ? <div className="advisor-message">{error}</div> : null}
 
       <section className="advisor-hero">
@@ -295,6 +295,6 @@ export default function FinancialAdvisorPage() {
           </div>
         </section>
       </div>
-    </main>
+    </div>
   );
 }

--- a/buck/src/app/dashboard/forecast/page.tsx
+++ b/buck/src/app/dashboard/forecast/page.tsx
@@ -63,7 +63,7 @@ export default function ForecastPage() {
   }
 
   return (
-    <main className="forecast-page">
+    <div className="forecast-page">
       {error && <div className="settings-message settings-message--error">{error}</div>}
 
       <section className="forecast-hero">
@@ -115,6 +115,6 @@ export default function ForecastPage() {
           </div>
         </section>
       </div>
-    </main>
+    </div>
   );
 }

--- a/buck/src/app/dashboard/settings/page.tsx
+++ b/buck/src/app/dashboard/settings/page.tsx
@@ -645,7 +645,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <main className="settings-page">
+    <div className="settings-page">
 
       {notice ? (
         <div className="settings-message settings-message--success">
@@ -1312,6 +1312,6 @@ export default function SettingsPage() {
           </section>
         </div>
       ) : null}
-    </main>
+    </div>
   );
 }

--- a/buck/src/app/dashboard/settings/style.css
+++ b/buck/src/app/dashboard/settings/style.css
@@ -89,7 +89,7 @@
   display: flex;
   align-items: center;
   gap: 0.85rem;
-  min-width: min(320px, 100%);
+  width: 100%;
   padding: 0.7rem;
   background: rgba(255, 197, 71, 0.12);
   border: 1px solid rgba(244, 117, 54, 0.22);

--- a/buck/src/app/dashboard/wallet/page.tsx
+++ b/buck/src/app/dashboard/wallet/page.tsx
@@ -197,13 +197,13 @@ export default function WalletPage() {
   }
 
   return (
-    <main className="settings-page">
+    <div className="settings-page">
       {error && <div className="settings-message settings-message--error">{error}</div>}
 
       <div className="wallet-grid">
         <article className="settings-card">
-          <div className="settings-card-heading" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
-            <div style={{ display: 'flex', gap: '1rem' }}>
+          <div className="settings-card-heading settings-card-header">
+            <div className="settings-card-title">
               <span aria-hidden="true">
                 <FaWallet />
               </span>
@@ -277,21 +277,13 @@ export default function WalletPage() {
                 >
                   {editId === w.id ? (
                     <>
-                      <div className="settings-wallet-info" style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                      <div className="settings-wallet-info settings-wallet-edit-grid">
                         <input
                           type="text"
                           value={editName}
                           onChange={(e) => setEditName(e.target.value)}
                           placeholder="Wallet Name"
                           className="settings-form-input"
-                          style={{
-                            width: "100%",
-                            padding: "0.5rem",
-                            borderRadius: "4px",
-                            border: "1px solid var(--buck-line)",
-                            background: "transparent",
-                            color: "var(--buck-ink)"
-                          }}
                         />
                         <input
                           type="number"
@@ -301,22 +293,13 @@ export default function WalletPage() {
                           min="0.01"
                           step="0.01"
                           className="settings-form-input"
-                          style={{
-                            width: "100%",
-                            padding: "0.5rem",
-                            borderRadius: "4px",
-                            border: "1px solid var(--buck-line)",
-                            background: "transparent",
-                            color: "var(--buck-ink)"
-                          }}
                         />
                       </div>
-                      <div className="settings-wallet-actions" style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", marginTop: "1rem", width: "100%" }}>
+                      <div className="settings-wallet-actions">
                         <button
                           className="settings-button settings-button--primary"
                           onClick={() => handleEditSave(w.id)}
                           type="button"
-                          style={{ flex: 1, margin: 0 }}
                         >
                           Save
                         </button>
@@ -324,7 +307,6 @@ export default function WalletPage() {
                           className="settings-button settings-button--secondary"
                           onClick={handleEditCancel}
                           type="button"
-                          style={{ flex: 1, margin: 0 }}
                         >
                           Cancel
                         </button>
@@ -332,7 +314,7 @@ export default function WalletPage() {
                     </>
                   ) : (
                     <>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', width: '100%' }}>
+                      <div className="settings-wallet-header">
                         <div className="settings-wallet-info">
                           <strong>{w.name}</strong>
                           <span className="settings-wallet-budget">{formatCurrency(Number(w.budget))}</span>
@@ -343,7 +325,7 @@ export default function WalletPage() {
                           </span>
                         )}
                       </div>
-                      <div className="settings-wallet-actions" style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", marginTop: "1rem", width: "100%" }}>
+                      <div className="settings-wallet-actions">
                         {w.id !== activeWalletId && (
                           <button
                             className="settings-button settings-button--secondary"
@@ -380,8 +362,8 @@ export default function WalletPage() {
         </article>
 
         <article className="settings-card">
-          <div className="settings-card-heading" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '1rem' }}>
-            <div style={{ display: 'flex', gap: '1rem' }}>
+          <div className="settings-card-heading settings-card-header">
+            <div className="settings-card-title">
               <span aria-hidden="true">
                 <FaHistory />
               </span>
@@ -423,8 +405,8 @@ export default function WalletPage() {
               filteredHistoryWallets.map((w) => (
                 <div key={w.id} className="settings-action-panel settings-wallet-item" style={{ opacity: w.deletedAt ? 0.6 : 1 }}>
                   <div className="settings-wallet-info" style={{ width: '100%' }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                    <div className="settings-wallet-header">
+                      <div className="settings-card-title" style={{ gap: '0.5rem' }}>
                         <strong style={{ textDecoration: w.deletedAt ? 'line-through' : 'none' }}>{w.name}</strong>
                         {w.deletedAt && (
                           <span style={{ fontSize: '0.7rem', background: 'var(--buck-surface)', color: 'var(--buck-muted)', padding: '0.1rem 0.4rem', borderRadius: '4px', border: '1px solid var(--buck-line)' }}>
@@ -483,6 +465,6 @@ export default function WalletPage() {
           onClose={() => setIsModalOpen(false)}
         />
       )}
-    </main>
+    </div>
   );
 }

--- a/buck/src/app/forgot-password/page.tsx
+++ b/buck/src/app/forgot-password/page.tsx
@@ -80,6 +80,7 @@ const ForgotPassword = () => {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
+      if (!supabase) return;
       if (event === "INITIAL_SESSION") {
         if (hasRecoveryToken) {
           if (session) {

--- a/buck/src/app/forgot-password/page.tsx
+++ b/buck/src/app/forgot-password/page.tsx
@@ -57,6 +57,8 @@ const ForgotPassword = () => {
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const isDarkTheme = useAuthPageTheme();
   const resetButton = usePointerGradient<HTMLButtonElement>();
   const passwordPolicy = evaluatePasswordPolicy(newPassword, { email });
@@ -73,17 +75,43 @@ const ForgotPassword = () => {
       window.location.hash.includes("type=recovery") ||
       window.location.search.includes("type=recovery");
 
-    if (hasRecoveryToken) {
-      setIsRecoveryMode(true);
-    }
+    if (!supabase) return;
 
     const {
       data: { subscription },
-    } = supabase?.auth.onAuthStateChange((event) => {
-      if (event === "PASSWORD_RECOVERY") {
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === "INITIAL_SESSION") {
+        if (hasRecoveryToken) {
+          if (session) {
+            setIsRecoveryMode(true);
+          } else if (window.location.hash.includes("access_token")) {
+            // Fallback for older implicit flow email templates
+            const hashParams = new URLSearchParams(window.location.hash.substring(1));
+            const access_token = hashParams.get("access_token");
+            const refresh_token = hashParams.get("refresh_token");
+
+            if (access_token && refresh_token) {
+              supabase.auth.setSession({ access_token, refresh_token }).then(({ data, error }) => {
+                if (!error && data.session) {
+                  setIsRecoveryMode(true);
+                  setError("");
+                  window.history.replaceState(null, "", window.location.pathname + "?type=recovery");
+                } else {
+                  setError("This password reset link is invalid or has expired.");
+                }
+              });
+            } else {
+              setError("This password reset link is invalid or has expired.");
+            }
+          } else {
+            setError("This password reset link is invalid or has expired.");
+          }
+        }
+      } else if (event === "PASSWORD_RECOVERY" || (hasRecoveryToken && session)) {
         setIsRecoveryMode(true);
+        setError("");
       }
-    }) ?? { data: { subscription: null } };
+    });
 
     return () => {
       subscription?.unsubscribe();
@@ -285,16 +313,33 @@ const ForgotPassword = () => {
                   <label htmlFor="new-password" className="FP-Label">
                     New password
                   </label>
-                  <input
-                    id="new-password"
-                    type="password"
-                    value={newPassword}
-                    onChange={(e) => setNewPassword(e.target.value)}
-                    className="FP-Input"
-                    placeholder="Create a new password"
-                    autoComplete="new-password"
-                    disabled={isSubmitting}
-                  />
+                  <div className="FP-InputWrapper">
+                    <input
+                      id="new-password"
+                      type={showNewPassword ? "text" : "password"}
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      className="FP-Input"
+                      placeholder="Create a new password"
+                      autoComplete="new-password"
+                      disabled={isSubmitting}
+                    />
+                    <button
+                      type="button"
+                      className="FP-Eye-Btn"
+                      tabIndex={-1}
+                      onClick={() => setShowNewPassword((v) => !v)}
+                      aria-label={showNewPassword ? "Hide password" : "Show password"}
+                      disabled={isSubmitting}
+                    >
+                      <Image
+                        src={showNewPassword ? "/duck-eye.png" : "/duck-eye-closed.png"}
+                        alt=""
+                        width={24}
+                        height={24}
+                      />
+                    </button>
+                  </div>
                   {newPassword ? (
                     <div
                       className={`FP-PasswordFeedback FP-PasswordFeedback--${passwordPolicy.strength}`}
@@ -325,16 +370,33 @@ const ForgotPassword = () => {
                   <label htmlFor="confirm-password" className="FP-Label">
                     Confirm password
                   </label>
-                  <input
-                    id="confirm-password"
-                    type="password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    className="FP-Input"
-                    placeholder="Confirm your new password"
-                    autoComplete="new-password"
-                    disabled={isSubmitting}
-                  />
+                  <div className="FP-InputWrapper">
+                    <input
+                      id="confirm-password"
+                      type={showConfirmPassword ? "text" : "password"}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      className="FP-Input"
+                      placeholder="Confirm your new password"
+                      autoComplete="new-password"
+                      disabled={isSubmitting}
+                    />
+                    <button
+                      type="button"
+                      className="FP-Eye-Btn"
+                      tabIndex={-1}
+                      onClick={() => setShowConfirmPassword((v) => !v)}
+                      aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+                      disabled={isSubmitting}
+                    >
+                      <Image
+                        src={showConfirmPassword ? "/duck-eye.png" : "/duck-eye-closed.png"}
+                        alt=""
+                        width={24}
+                        height={24}
+                      />
+                    </button>
+                  </div>
                   {confirmStatus ? (
                     <p
                       className={`FP-ConfirmHint${

--- a/buck/src/app/forgot-password/style.css
+++ b/buck/src/app/forgot-password/style.css
@@ -284,6 +284,46 @@ html[data-buck-theme="dark"] .FP-Background {
   box-shadow: 0 0 0 3px rgba(255, 197, 71, 0.12);
 }
 
+.FP-InputWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.FP-InputWrapper .FP-Input {
+  padding-right: 2.8rem;
+}
+
+.FP-Eye-Btn {
+  position: absolute;
+  right: 0.8rem;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  z-index: 2;
+  opacity: 0.76;
+  transition:
+    background 180ms ease,
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.FP-Eye-Btn img {
+  filter: invert(83%) sepia(64%) saturate(684%) hue-rotate(338deg) brightness(104%) contrast(101%);
+  transition: filter 180ms ease;
+}
+
+.FP-Eye-Btn:hover {
+  background: rgba(255, 197, 71, 0.12);
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
 .FP-Input:-webkit-autofill,
 .FP-Input:-webkit-autofill:hover {
   border-color: rgba(255, 211, 154, 0.2);

--- a/buck/src/component/dashboard.css
+++ b/buck/src/component/dashboard.css
@@ -143,6 +143,8 @@ html[data-buck-theme="dark"] .dashboard-mascot {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  width: 100%;
   gap: 1rem;
   min-height: 76px;
   padding: clamp(0.8rem, 1.6vw, 1rem) clamp(1rem, 2.6vw, 1.6rem);
@@ -888,13 +890,18 @@ html[data-buck-theme="dark"] .dashboard-skeleton-bars span {
   }
 }
 
-@media (max-width: 980px) {
+@media (max-width: 1024px) {
   .dashboard {
-    display: block;
+    display: flex;
+    flex-direction: column;
   }
 
   .dashboard-main {
     min-width: 0;
+    width: 100%;
+    min-height: 0;
+    height: auto;
+    flex: 1;
   }
 
   .dashboard-topbar {
@@ -903,6 +910,8 @@ html[data-buck-theme="dark"] .dashboard-skeleton-bars span {
     min-height: auto;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
+    width: 100%;
     flex-direction: row;
     gap: 0.5rem;
     padding: 0.85rem 1rem;
@@ -924,7 +933,7 @@ html[data-buck-theme="dark"] .dashboard-skeleton-bars span {
 
   .dashboard-header-inner {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
     gap: 0.8rem;
     width: min(1180px, 100%);

--- a/buck/src/hooks/useAuthPageTheme.ts
+++ b/buck/src/hooks/useAuthPageTheme.ts
@@ -49,11 +49,7 @@ export const applyDocumentTheme = (theme: LandingTheme) => {
 };
 
 export function useAuthPageTheme() {
-  const [isDarkTheme, setIsDarkTheme] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
-    return resolveLandingTheme(mediaQuery) === "dark";
-  });
+  const [isDarkTheme, setIsDarkTheme] = useState(false);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");

--- a/buck/src/middleware.ts
+++ b/buck/src/middleware.ts
@@ -401,14 +401,20 @@ export async function middleware(request: NextRequest) {
   }
 
   if (isAuthRoute && user) {
-    const redirectResponse = NextResponse.redirect(
-      createDashboardRedirect(request)
-    );
-    copyResponseCookies(response, redirectResponse);
-    await refreshActivityCookie(redirectResponse, user.id);
-    setNoStoreHeaders(redirectResponse);
+    const isRecoveryMode =
+      pathname === "/forgot-password" &&
+      request.nextUrl.searchParams.get("type") === "recovery";
 
-    return redirectResponse;
+    if (!isRecoveryMode) {
+      const redirectResponse = NextResponse.redirect(
+        createDashboardRedirect(request)
+      );
+      copyResponseCookies(response, redirectResponse);
+      await refreshActivityCookie(redirectResponse, user.id);
+      setNoStoreHeaders(redirectResponse);
+
+      return redirectResponse;
+    }
   }
 
   return response;


### PR DESCRIPTION
Add robust auth callback handling: support token_hash OTP verify flow, detect implicit hash fragments (access_token) via a small HTML fallback, and preserve existing code exchange logic. Improve forgot-password flow: handle implicit recovery tokens, set session from hash when present, add show/hide password controls and corresponding CSS. Replace <main> wrappers with <div> in several dashboard pages for layout consistency and update settings/wallet markup to use CSS classes instead of many inline styles (wallet UI refactor). Adjust styles: change settings card sizing, improve dashboard responsive rules and header layout. Simplify useAuthPageTheme initial state and avoid redirecting authenticated users to dashboard when on password recovery route in middleware.