### PR TITLE
[Update] -> Security Fix

### DIFF
--- a/buck/src/app/auth/callback/route.ts
+++ b/buck/src/app/auth/callback/route.ts
@@ -11,9 +11,16 @@ function getSafeNextPath(value: string | null) {
   if (!value) return "/dashboard/home";
 
   try {
-    const parsedUrl = new URL(value, "http://localhost");
+    // We use a dummy base URL strictly for parsing purposes to utilize the native URL object.
+    // This ensures the value is a relative path. If the attacker provides an absolute URL 
+    // (e.g. "https://evil.com"), the origin will NOT match the dummy base, and it will be rejected.
+    // This works flawlessly in production because it only returns the relative pathname.
+    const parsedUrl = new URL(value, "http://dummy.local");
     
-    if (parsedUrl.origin === "http://localhost" && parsedUrl.pathname.startsWith("/dashboard")) {
+    if (
+      parsedUrl.origin === "http://dummy.local" && 
+      (parsedUrl.pathname.startsWith("/dashboard") || parsedUrl.pathname === "/forgot-password")
+    ) {
       return parsedUrl.pathname + parsedUrl.search;
     }
   } catch (e) {

--- a/buck/src/app/sign-in/page.tsx
+++ b/buck/src/app/sign-in/page.tsx
@@ -52,12 +52,14 @@ function getSafeRedirectPath(redirectTo: string | null) {
   if (!redirectTo) return "/dashboard/home";
 
   try {
-    // Validate by attempting to parse as a full URL with a dummy origin.
-    // This safely resolves any path traversals or protocol-relative injections.
-    const parsedUrl = new URL(redirectTo, "http://localhost");
+    // We use a dummy base URL strictly for parsing purposes to utilize the native URL object.
+    // This ensures the value is a relative path. If the attacker provides an absolute URL 
+    // (e.g. "https://evil.com"), the origin will NOT match the dummy base, and it will be rejected.
+    // This works flawlessly in production because it only returns the relative pathname.
+    const parsedUrl = new URL(redirectTo, "http://dummy.local");
     
     // Check if it's strictly a relative path going to the dashboard
-    if (parsedUrl.origin === "http://localhost" && parsedUrl.pathname.startsWith("/dashboard")) {
+    if (parsedUrl.origin === "http://dummy.local" && parsedUrl.pathname.startsWith("/dashboard")) {
       // Return pathname + search (preserves query params, but ignores potential malicious fragments)
       return parsedUrl.pathname + parsedUrl.search;
     }


### PR DESCRIPTION
Switch parsing base from http://localhost to http://dummy.local in auth callback and sign-in redirect helpers to ensure only relative paths are accepted and external absolute URLs are rejected. Added explanatory comments about using a dummy origin and preserved pathname+search when returning safe redirects. Also expanded allowed callback path to include /forgot-password in the auth callback route to permit that internal redirect.