### PR TITLE
[Update][Fix] -> Require Supabase auth for admin routes

### DIFF
--- a/buck/src/app/api/admin/supabase/route.ts
+++ b/buck/src/app/api/admin/supabase/route.ts
@@ -1,6 +1,26 @@
 import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { supabaseAnonKey, supabaseCookieOptions, supabaseUrl } from "@/utils/supabaseConfig";
+import { cookies } from "next/headers";
 
 export async function GET() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(supabaseUrl!, supabaseAnonKey!, {
+    cookieOptions: supabaseCookieOptions,
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll() {}
+    },
+  });
+
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user || user.email !== "buckthebudgettracker@gmail.com") {
+    return NextResponse.json({ error: "Unauthorized access" }, { status: 403 });
+  }
+
   const token = process.env.SUPABASE_MANAGEMENT_TOKEN;
   const projectRef = process.env.SUPABASE_PROJECT_REF;
 

--- a/buck/src/app/api/admin/vercel/route.ts
+++ b/buck/src/app/api/admin/vercel/route.ts
@@ -1,6 +1,26 @@
 import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { supabaseAnonKey, supabaseCookieOptions, supabaseUrl } from "@/utils/supabaseConfig";
+import { cookies } from "next/headers";
 
 export async function GET() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(supabaseUrl!, supabaseAnonKey!, {
+    cookieOptions: supabaseCookieOptions,
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll() {}
+    },
+  });
+
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user || user.email !== "buckthebudgettracker@gmail.com") {
+    return NextResponse.json({ error: "Unauthorized access" }, { status: 403 });
+  }
+
   const token = process.env.VERCEL_ACCESS_TOKEN;
   const projectId = process.env.VERCEL_PROJECT_ID;
 


### PR DESCRIPTION
Create a Supabase server client in the admin API endpoints and verify the authenticated user via cookies. Both now fetch the current user and only allow access for buckthebudgettracker@gmail.com, returning 403 for unauthorized requests. Environment-based management tokens ) are left intact for the downstream admin operations.