### PR TITLE
[Update] -> Ignore deleted wallets and update dashboard cache

### DIFF
--- a/buck/src/app/dashboard/home/page.tsx
+++ b/buck/src/app/dashboard/home/page.tsx
@@ -236,7 +236,7 @@ export default function Dashboard() {
         
         let activeWalletBudget = null;
         if (activeWalletId && loadedWallets) {
-          const activeWallet = loadedWallets.find((w) => w.id === activeWalletId);
+          const activeWallet = loadedWallets.find((w) => w.id === activeWalletId && !w.deletedAt);
           if (activeWallet) {
             activeWalletBudget = Number(activeWallet.budget);
           }

--- a/buck/src/app/dashboard/wallet/WalletModal.tsx
+++ b/buck/src/app/dashboard/wallet/WalletModal.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 import styles from "./WalletModal.module.css";
 import { motion } from "framer-motion";
 import { useOptionalDashboardUser } from "@/context/DashboardUserContext";
+import { useFinancial } from "@/context/FinancialContext";
 import { usePointerGradient } from "@/hooks/usePointerGradient";
 import { formatCurrency } from "@/utils/formatters";
 import {
@@ -42,6 +43,7 @@ export default function WalletModal({
   const [portalReady, setPortalReady] = useState(false);
 
   const user = useOptionalDashboardUser();
+  const { setDashboardCache } = useFinancial();
 
   useEffect(() => {
     setPortalReady(true);
@@ -67,10 +69,23 @@ export default function WalletModal({
       const walletsArr = await listWallets(user.uid);
       setWallets(walletsArr);
 
-      if (walletsArr.length === 1) {
-        await setActiveWallet(user.uid, walletsArr[0].id);
-        setActiveWalletId(walletsArr[0].id);
+      const activeWalletsList = walletsArr.filter((w) => !w.deletedAt);
+      let newActiveId = activeWalletId;
+
+      if (activeWalletsList.length === 1) {
+        newActiveId = activeWalletsList[0].id;
+        await setActiveWallet(user.uid, newActiveId);
+        setActiveWalletId(newActiveId);
       }
+
+      const activeWallet = walletsArr.find((w) => w.id === newActiveId && !w.deletedAt);
+
+      setDashboardCache((current) => ({
+        ...current,
+        wallets: walletsArr,
+        ...(newActiveId ? { activeWalletId: newActiveId } : {}),
+        ...(activeWallet ? { activeWalletBudget: activeWallet.budget } : { activeWalletBudget: 0 }),
+      }));
     } catch (error) {
       setError(error instanceof Error ? error.message : "Failed to load wallets.");
     } finally {
@@ -168,6 +183,13 @@ export default function WalletModal({
     setActiveWalletId(id);
     setJustActivatedId(id);
     setTimeout(() => setJustActivatedId(null), 900);
+
+    const newActiveWallet = wallets.find((w) => w.id === id);
+    setDashboardCache((current) => ({
+      ...current,
+      activeWalletId: id,
+      ...(newActiveWallet ? { activeWalletBudget: newActiveWallet.budget } : {}),
+    }));
   };
 
   const activeWallets = wallets.filter(w => !w.deletedAt);

--- a/buck/src/app/dashboard/wallet/page.tsx
+++ b/buck/src/app/dashboard/wallet/page.tsx
@@ -53,13 +53,23 @@ export default function WalletPage() {
     try {
       const walletsArr = await listWallets(user.uid);
       setWallets(walletsArr);
-      setDashboardCache((current) => mergeDashboardDataCache(current, user.uid, { wallets: walletsArr }));
       
-      if (walletsArr.length === 1 && !activeWalletId) {
-        await setActiveWallet(user.uid, walletsArr[0].id);
-        setActiveWalletId(walletsArr[0].id);
-        setDashboardCache((current) => mergeDashboardDataCache(current, user.uid, { activeWalletId: walletsArr[0].id }));
+      const activeWalletsList = walletsArr.filter(w => !w.deletedAt);
+      let newActiveId = activeWalletId;
+
+      if (activeWalletsList.length === 1 && !newActiveId) {
+        newActiveId = activeWalletsList[0].id;
+        await setActiveWallet(user.uid, newActiveId);
+        setActiveWalletId(newActiveId);
       }
+
+      const activeWallet = walletsArr.find((w) => w.id === newActiveId && !w.deletedAt);
+
+      setDashboardCache((current) => mergeDashboardDataCache(current, user.uid, { 
+        wallets: walletsArr,
+        ...(newActiveId ? { activeWalletId: newActiveId } : {}),
+        ...(activeWallet ? { activeWalletBudget: activeWallet.budget } : { activeWalletBudget: 0 }),
+      }));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load wallets.");
     } finally {
@@ -85,7 +95,7 @@ export default function WalletPage() {
       if (activeWalletId === id) {
         await setActiveWallet(user.uid, null);
         setActiveWalletId(null);
-        setDashboardCache((current) => mergeDashboardDataCache(current, user.uid, { activeWalletId: null }));
+        setDashboardCache((current) => mergeDashboardDataCache(current, user.uid, { activeWalletId: null, activeWalletBudget: 0 }));
       }
       fetchWallets();
     } catch (err) {
@@ -168,6 +178,12 @@ export default function WalletPage() {
     if (!user) return;
     await setActiveWallet(user.uid, id);
     setActiveWalletId(id);
+
+    const newActiveWallet = wallets.find((w) => w.id === id);
+    setDashboardCache((current) => mergeDashboardDataCache(current, user.uid, {
+      activeWalletId: id,
+      ...(newActiveWallet ? { activeWalletBudget: newActiveWallet.budget } : {}),
+    }));
   };
 
   const activeWallets = wallets.filter(w => !w.deletedAt);

--- a/buck/src/utils/supabaseData.ts
+++ b/buck/src/utils/supabaseData.ts
@@ -1157,7 +1157,8 @@ export async function getActiveWallet(userId: string) {
   }
 
   const safeUserId = assertUuid(userId, "user id");
-  const wallets = await listWallets(safeUserId);
+  const allWallets = await listWallets(safeUserId);
+  const wallets = allWallets.filter(w => !w.deletedAt);
   let activeWalletId = await getActiveWalletId(safeUserId);
 
   if (!activeWalletId && wallets.length === 1) {


### PR DESCRIPTION
Filter out wallets with a deletedAt flag when building wallet lists and determining the active wallet. Add dashboard cache updates to include activeWalletBudget whenever wallets are loaded, activated, or cleared (set to 0 on deactivation). Import and use useFinancial in WalletModal to update the cache on load/activation. Also update getActiveWallet to ignore deleted wallets before deciding a single-wallet auto-activation.