### PR TITLE
[Update] -> Fixed Scroll animation in Homepage

### DIFF
--- a/buck/src/app/globals.css
+++ b/buck/src/app/globals.css
@@ -656,8 +656,7 @@ main {
   transition:
     background 180ms ease,
     border-color 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease;
+    box-shadow 180ms ease;
 }
 
 .landing-page--dark .hero-stat {
@@ -686,7 +685,6 @@ main {
   background: rgba(255, 253, 249, 0.94);
   border-color: rgba(239, 138, 87, 0.65);
   box-shadow: 0 18px 38px rgba(94, 59, 34, 0.13);
-  transform: translateY(-5px);
 }
 
 .landing-page--dark .hero-stat:hover {
@@ -932,8 +930,7 @@ main {
   transition:
     background 180ms ease,
     border-color 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease;
+    box-shadow 180ms ease;
 }
 
 .feature-card {
@@ -973,7 +970,6 @@ main {
   background: #fffdf9;
   border-color: rgba(239, 138, 87, 0.65);
   box-shadow: 0 22px 48px rgba(94, 59, 34, 0.14);
-  transform: translateY(-6px);
 }
 
 .landing-page--dark .feature-card:hover,
@@ -1095,8 +1091,7 @@ main {
   box-shadow: var(--buck-shadow);
   transition:
     border-color 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease;
+    box-shadow 180ms ease;
 }
 
 .adviser-card::before {
@@ -1129,7 +1124,6 @@ main {
   background: #fffdf9;
   border-color: rgba(239, 138, 87, 0.68);
   box-shadow: 0 22px 48px rgba(94, 59, 34, 0.14);
-  transform: translateY(-6px);
 }
 
 .adviser-card:hover::after {

--- a/buck/src/app/page.tsx
+++ b/buck/src/app/page.tsx
@@ -34,8 +34,8 @@ const heroWords = ["Buck", "Budget", "Tracker"];
 const adviserRotationDelay = 6800;
 const revealViewport = { once: true, amount: 0.2 };
 const cardLiftHover: TargetAndTransition = {
-  y: -8,
-  transition: { duration: 0.18, ease: [0.22, 1, 0.36, 1] },
+  y: -7,
+  transition: { duration: 0.16, ease: "easeOut" },
 };
 
 const weeklyPreviewSnapshots = [
@@ -207,16 +207,16 @@ const heroWordContainer: Variants = {
 const revealVariants: Variants = {
   hidden: {
     opacity: 0,
-    y: 28,
-    filter: "blur(8px)",
+    y: 20,
+    filter: "blur(4px)",
   },
   visible: {
     opacity: 1,
     y: 0,
     filter: "blur(0px)",
     transition: {
-      duration: 0.58,
-      ease: [0.22, 1, 0.36, 1],
+      duration: 0.38,
+      ease: "easeOut",
     },
   },
 };
@@ -226,8 +226,8 @@ const revealGroupVariants: Variants = {
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.09,
-      delayChildren: 0.08,
+      staggerChildren: 0.055,
+      delayChildren: 0.035,
     },
   },
 };
@@ -235,16 +235,14 @@ const revealGroupVariants: Variants = {
 const revealCardVariants: Variants = {
   hidden: {
     opacity: 0,
-    y: 22,
-    filter: "blur(6px)",
+    y: 14,
   },
   visible: {
     opacity: 1,
     y: 0,
-    filter: "blur(0px)",
     transition: {
-      duration: 0.5,
-      ease: [0.22, 1, 0.36, 1],
+      duration: 0.3,
+      ease: "easeOut",
     },
   },
 };
@@ -252,13 +250,11 @@ const revealCardVariants: Variants = {
 function Reveal({
   children,
   className,
-  delay = 0,
   hoverLift = false,
   scrollAnchor = false,
 }: {
   children: ReactNode;
   className?: string;
-  delay?: number;
   hoverLift?: boolean;
   scrollAnchor?: boolean;
 }) {
@@ -271,7 +267,6 @@ function Reveal({
       whileInView="visible"
       whileHover={hoverLift ? cardLiftHover : undefined}
       viewport={revealViewport}
-      transition={{ delay }}
     >
       {children}
     </motion.div>


### PR DESCRIPTION
Remove CSS translateY properties and transform transitions from multiple card/hero selectors so transforms are no longer applied via static CSS. Update Framer Motion settings in page.tsx to use smaller y offsets, shorter durations, reduced blur, straighter ease (easeOut), and tighter stagger/delay values. Also remove the Reveal component's delay prop/usage. These changes consolidate transform handling to motion animations and make the UI animations snappier and less visually heavy.